### PR TITLE
ARM32: fix svc handling

### DIFF
--- a/qemu/accel/tcg/cpu-exec.c
+++ b/qemu/accel/tcg/cpu-exec.c
@@ -398,6 +398,10 @@ static inline bool cpu_handle_exception(CPUState *cpu, int *ret)
         CPUPPCState *env = &(POWERPC_CPU(uc->cpu)->env);
         env->nip += 4;
 #endif
+#if defined(TARGET_ARM)
+        CPUARMState *env = &(ARM_CPU(uc->cpu)->env);
+        cpu->exception_index=env->exception.syndrome&0xff; //save svc call number so it will be passed to uc-hook
+#endif
         // Unicorn: call registered interrupt callbacks
         catched = false;
         HOOK_FOREACH_VAR_DECLARE;


### PR DESCRIPTION
Currently svc $n always passes 2 for `intno` to the hook, this PR should fix this. See #2153.